### PR TITLE
PiDigit realisation in Python

### DIFF
--- a/pidigit.py
+++ b/pidigit.py
@@ -2,11 +2,10 @@ import mpmath as mp
 
 class PiDigit(int):
     def __new__(cls, startPos, endPos):
-        mp.dps = endPos + 5
         startPos = startPos
         endPos = endPos
-        pi = mp.nstr(mp.pi, endPos + 1)[1:]
-        value = int(pi[startPos - 1 : endPos])
+        pi = mp.nstr(mp.pi, endPos + 5)[1:]
+        value = int(pi[startPos - 1 : endPos]) if startPos - 1 != endPos else int(pi[startPos-1])
         obj = super().__new__(cls, value)
         obj.startPos = startPos
         obj.end = endPos

--- a/pidigit.py
+++ b/pidigit.py
@@ -1,0 +1,20 @@
+import mpmath as mp
+
+class PiDigit(int):
+    def __new__(cls, startPos, endPos):
+        mp.dps = endPos + 5
+        startPos = startPos
+        endPos = endPos
+        pi = mp.nstr(mp.pi, endPos + 1)[1:]
+        value = int(pi[startPos - 1 : endPos])
+        obj = super().__new__(cls, value)
+        obj.startPos = startPos
+        obj.end = endPos
+        obj.pi = pi
+        obj.value = value
+        return obj
+
+    def __str__(self):
+        return str(self.value)
+    def __repr__(self):
+        return str(f"PiDigit with startPos - {self.startPos}, endPos - {self.endPos} and value equal to {str(self)}")


### PR DESCRIPTION
Made it by creating a **class** based on int. 

# Guide

## Atributes
- `value`  - storages *int* value of a PiDigit. For example, ```python x = PiDigit(2,3); x.value``` will be 14
- `pi` - storages special pi of a PiDigit. For example, `PiDigit(2,3)` will store only `.1415927`, while `PiDigit(20,30)` will store `.1415926535897931159979634685441852`
- `startPos` and `endPos` - store start position and end position in pi 

## Capabilities
Long story short, PiDigit can do all things that int can in the same way, for example, you can add to PiDigits using `+`. Only thing that differs is that PiDigit `__repr__()` is `PiDigit with startPos - {startPos}, endPos - {endPos} and value equal to {value}`

That's it